### PR TITLE
Added the error control operator to `fopen()` calls

### DIFF
--- a/src/FromFileObservable.php
+++ b/src/FromFileObservable.php
@@ -26,7 +26,7 @@ class FromFileObservable extends Observable
     public function _subscribe(ObserverInterface $observer): DisposableInterface
     {
         try {
-            $stream = new StreamSubject(fopen($this->fileName, $this->mode), $this->loop);
+            $stream = new StreamSubject(@fopen($this->fileName, $this->mode), $this->loop);
 
             return $stream->subscribe($observer);
 

--- a/src/ToFileObserver.php
+++ b/src/ToFileObserver.php
@@ -6,6 +6,6 @@ class ToFileObserver extends StreamSubject
 {
     public function __construct(string $fileName)
     {
-        parent::__construct(fopen($fileName, 'wb'));
+        parent::__construct(@fopen($fileName, 'wb'));
     }
 }


### PR DESCRIPTION
Fixes the issue #2