### PR TITLE
Forward compatibility with voryx/event-loop 3.0 and while supporting 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
   },
   "require": {
     "php": "^7.0",
-    "voryx/event-loop": "^2.0",
+    "voryx/event-loop": "^3.0 || ^2.0",
     "react/stream": "^0.7.0",
     "reactivex/rxphp": "^2.0",
     "rx/operator-extras": "^2.0"

--- a/tests/Functional/Observable/FromFileObservableTest.php
+++ b/tests/Functional/Observable/FromFileObservableTest.php
@@ -64,7 +64,10 @@ class FromFileObservableTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $loop->tick();
+        $loop->futureTick(function () use ($loop) {
+            $loop->stop();
+        });
+        $loop->run();
 
         $this->assertFalse($result);
         $this->assertFalse($complete);


### PR DESCRIPTION
As promised at https://github.com/voryx/event-loop/pull/1#issuecomment-382123772 here is the PR that updates this package to support voryx/event-loop 3.0 and 2.0.